### PR TITLE
Use new sdk package and version

### DIFF
--- a/connector-definition/template/requirements.txt
+++ b/connector-definition/template/requirements.txt
@@ -1,1 +1,1 @@
-hasura-ndc==0.38
+ndc-sdk-python==0.40


### PR DESCRIPTION
Hello! We've moved the Python NDC SDK to [https://pypi.org/project/ndc-sdk-python/](https://pypi.org/project/ndc-sdk-python/)

This updates this repo to use the most up to date version. I have checked the Dockerfile still builds, but I'm not sure how to actually get a connector up and running to check I haven't messed up the SDK. Any pointers?