### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ndc-python-lambda-connector.yaml
+++ b/.github/workflows/ndc-python-lambda-connector.yaml
@@ -20,8 +20,8 @@ jobs:
     name: Build and test ndc-lambda-sdk
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
     name: Test connector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Test example functions.py works
@@ -53,10 +53,10 @@ jobs:
       commit_hash: ${{ steps.get_commit_hash.outputs.commit_hash }}
       sha256: ${{ steps.calculate_checksum.outputs.sha256 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # This is important for git describe to work correctly
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Build connector
@@ -79,7 +79,7 @@ jobs:
           ls -la connector-definition/dist
           echo "Contents of connector-definition/dist/.hasura-connector:"
           ls -la connector-definition/dist/.hasura-connector
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: connector-definition
           path: ./connector-definition/dist
@@ -89,20 +89,20 @@ jobs:
     name: Build and scan Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           load: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
 
       - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
           format: json
@@ -110,7 +110,7 @@ jobs:
           scanners: vuln
 
       - name: Upload Trivy scan results to Security Agent
-        uses: hasura/security-agent-tools/upload-file@v1
+        uses: hasura/security-agent-tools/upload-file@f16c24be07f6cc89535b6fcdab29e15b1ee799b0 # v1
         with:
           file_path: trivy-results.json
           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
@@ -124,7 +124,7 @@ jobs:
             team=engine
 
       - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           skip-setup-trivy: true
           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
@@ -140,16 +140,16 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
@@ -157,12 +157,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: docker-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Build and Push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -177,7 +177,7 @@ jobs:
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
           format: json
@@ -185,7 +185,7 @@ jobs:
           scanners: vuln
 
       - name: Upload Trivy scan results to Security Agent
-        uses: hasura/security-agent-tools/upload-file@v1
+        uses: hasura/security-agent-tools/upload-file@f16c24be07f6cc89535b6fcdab29e15b1ee799b0 # v1
         with:
           file_path: trivy-results.json
           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
@@ -199,7 +199,7 @@ jobs:
             team=engine
 
       - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           skip-setup-trivy: true
           image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
@@ -218,9 +218,9 @@ jobs:
       - build-and-push-docker
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download connector definition
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: connector-definition
           path: ./connector-definition/dist
@@ -230,13 +230,13 @@ jobs:
           echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         shell: bash
 
-      - uses: mindsers/changelog-reader-action@v2
+      - uses: mindsers/changelog-reader-action@97a0b06549019bb99a571f1664272db18031acff # v2
         id: changelog-reader
         with:
           version: ${{ steps.get-version.outputs.tagged_version }}
           path: ./CHANGELOG.md
 
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@b21b43df682dab285bf5146c1955e7f3560805f8 # v1
         with:
           draft: false
           tag_name: v${{ steps.get-version.outputs.tagged_version }}


### PR DESCRIPTION
## Summary
- Pin all public GitHub Action references to their immutable commit SHAs
- Original version tags preserved as inline comments for maintainability
- Prevents supply chain attacks via mutable tag references

## Test plan
- [ ] Verify CI workflows still trigger and run correctly
- [ ] Spot-check a few pinned SHAs match their expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)