### PR TITLE
ci: disable trivy vulnerability scanning

### DIFF
--- a/.github/workflows/ndc-python-lambda-connector.yaml
+++ b/.github/workflows/ndc-python-lambda-connector.yaml
@@ -101,39 +101,39 @@ jobs:
           load: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
 
-      - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
-          format: json
-          output: trivy-results.json
-          scanners: vuln
-
-      - name: Upload Trivy scan results to Security Agent
-        uses: hasura/security-agent-tools/upload-file@v1
-        with:
-          file_path: trivy-results.json
-          security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
-          tags: |
-            service=ndc-python-lambda
-            source_code_path=.
-            docker_file_path=Dockerfile
-            scanner=trivy
-            image_name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
-            product_domain=hasura-ddn-data-plane,promptql-data-plane
-            team=engine
-
-      - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          skip-setup-trivy: true
-          image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
-          format: table
-          severity: CRITICAL,HIGH
-          scanners: vuln
-          ignore-unfixed: true
-          exit-code: 1
-
+#       - name: Run Trivy vulnerability scanner (json output)
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+#           format: json
+#           output: trivy-results.json
+#           scanners: vuln
+# 
+#       - name: Upload Trivy scan results to Security Agent
+#         uses: hasura/security-agent-tools/upload-file@v1
+#         with:
+#           file_path: trivy-results.json
+#           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
+#           tags: |
+#             service=ndc-python-lambda
+#             source_code_path=.
+#             docker_file_path=Dockerfile
+#             scanner=trivy
+#             image_name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+#             product_domain=hasura-ddn-data-plane,promptql-data-plane
+#             team=engine
+# 
+#       - name: Fail build on High/Critical Vulnerabilities
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           skip-setup-trivy: true
+#           image-ref: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+#           format: table
+#           severity: CRITICAL,HIGH
+#           scanners: vuln
+#           ignore-unfixed: true
+#           exit-code: 1
+# 
   build-and-push-docker:
     name: Build and push Docker image
     needs: build-connector
@@ -176,39 +176,39 @@ jobs:
           IMAGE_TAG="${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${GITHUB_REF#refs/tags/}"
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
-          format: json
-          output: trivy-results.json
-          scanners: vuln
-
-      - name: Upload Trivy scan results to Security Agent
-        uses: hasura/security-agent-tools/upload-file@v1
-        with:
-          file_path: trivy-results.json
-          security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
-          tags: |
-            service=ndc-python-lambda
-            source_code_path=.
-            docker_file_path=Dockerfile
-            scanner=trivy
-            image_name=${{ steps.get-image-tag.outputs.image_tag }}
-            product_domain=hasura-ddn-data-plane,promptql-data-plane
-            team=engine
-
-      - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          skip-setup-trivy: true
-          image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
-          format: table
-          severity: CRITICAL,HIGH
-          scanners: vuln
-          ignore-unfixed: true
-          exit-code: 1
-
+#       - name: Run Trivy vulnerability scanner (json output)
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
+#           format: json
+#           output: trivy-results.json
+#           scanners: vuln
+# 
+#       - name: Upload Trivy scan results to Security Agent
+#         uses: hasura/security-agent-tools/upload-file@v1
+#         with:
+#           file_path: trivy-results.json
+#           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
+#           tags: |
+#             service=ndc-python-lambda
+#             source_code_path=.
+#             docker_file_path=Dockerfile
+#             scanner=trivy
+#             image_name=${{ steps.get-image-tag.outputs.image_tag }}
+#             product_domain=hasura-ddn-data-plane,promptql-data-plane
+#             team=engine
+# 
+#       - name: Fail build on High/Critical Vulnerabilities
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           skip-setup-trivy: true
+#           image-ref: ${{ steps.get-image-tag.outputs.image_tag }}
+#           format: table
+#           severity: CRITICAL,HIGH
+#           scanners: vuln
+#           ignore-unfixed: true
+#           exit-code: 1
+# 
   release-connector:
     name: Release connector
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Disable Trivy vulnerability scanning steps/jobs in CI pipelines
- Trivy scan steps have been commented out from workflow/pipeline files

## Test plan
- [ ] Verify CI pipelines still run successfully without trivy steps
- [ ] Confirm no downstream jobs depend on the disabled scan steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)