### PR TITLE
chore(images): migrate OS base to private -stable alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20260113
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:noble-stable
 
 # Install Python 3.12 (Ubuntu Noble default), venv, curl, and git
 RUN apt-get update && \


### PR DESCRIPTION
## What

Re-homes the runtime/OS **base image** of this connector to Hasura's private Artifact Registry, using the floating `-stable` alias so rebuilds auto-inherit the latest patched base.

Per Hasura policy, every container deployed in Hasura infra must be pulled from the private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images`, not from upstream registries (Docker Hub, etc.). Switching to the `-stable` alias (same `noble`/24.04 version line, auto-patched) reduces CVE exposure on rebuild and brings the base pull into registry compliance.

## Exact FROM swap

`Dockerfile`:

```
- FROM ubuntu:noble-20260113
+ FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/ubuntu:noble-stable
```

This re-homes the dated pin to the floating `-stable` alias on the same Ubuntu Noble (24.04) line.

## Scope notes

- Only the top-level `Dockerfile` base is changed. `connector-definition/Dockerfile` is `FROM ghcr.io/hasura/ndc-python-lambda:...` — a self-reference to the published connector image, not a base to swap — and is intentionally left untouched.
- This repo has no builder `rust:` stages; any such builder/toolchain stages would be intentionally out of scope for this PR, which is limited to the runtime/OS base.
- This ties the runtime base pull to the private AR: external/OSS builds will need access to that registry (or a substitute base) to build successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)